### PR TITLE
HTTPRequest does not have attribute 'raw'.

### DIFF
--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -68,7 +68,7 @@ class Botocore(object):
             response_dict['body'] = http_response.body
         elif operation_model.has_streaming_output:
             response_dict['body'] = botocore.response.StreamingBody(
-                http_response.raw, response_dict['headers'].get('content-length'))
+                http_response.body, response_dict['headers'].get('content-length'))
         else:
             response_dict['body'] = http_response.body
         parser = self.endpoint._response_parser_factory.create_parser(operation_model.metadata['protocol'])


### PR DESCRIPTION
Replace with attribute 'body' for streaming output operation model in _process_response