### PR TITLE
fix urlparse dependency to support both python2 and python3

### DIFF
--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -1,8 +1,14 @@
 import logging
 
 from functools import partial
-from urlparse import urlparse
 
+try:
+    #python2
+    from urlparse import urlparse
+except ImportError:
+    #python3
+    from urllib.parse import urlparse
+    
 from requests.utils import get_environ_proxies
 from tornado.httpclient import HTTPClient, AsyncHTTPClient, HTTPRequest, HTTPError
 


### PR DESCRIPTION
Addresses issue #10