### PR TITLE
Fix error with bytes upload

### DIFF
--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -64,11 +64,15 @@ class Botocore(object):
         adapter.cert_verify(conn, request.url, verify=True, cert=None)
         adapter.add_headers(request)
 
+        req_body = request.body
+        if req_body and req_body.buf:
+            req_body = req_body.buf
+
         request = HTTPRequest(
             url=request.url,
             headers=request.headers,
             method=request.method,
-            body=request.body,
+            body=req_body,
             validate_cert=False,
             proxy_host=self.proxy_host,
             proxy_port=self.proxy_port


### PR DESCRIPTION
Thanks for merging the previous PR @nanvel :) Regarding the req_body edit, my tests are failing without it, can I ask what version of botocore you tested it?

Basically, my test is failing when I'm sending data to a S3 bucket, here's the code calling tornado-botocore:

```.py
       args = dict(
            callback=callback,
            Bucket=self._bucket,
            Key=self._clean_key(path),
            Body=data,
            ContentType=content_type,
            Metadata=metadata,
            StorageClass=storage_class,
        )

        if encrypt_key:
            args['ServerSideEncryption'] = 'AES256'

        my_session = session_handler.get_session(self._endpoint is not None)
        session = Botocore(service='s3', region_name=self._region,
                           operation='PutObject', session=my_session,
                           endpoint_url=self._endpoint)

        session.call(**args)
```

With data being bytes.

My test fails with the following stacktrace:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/pyvows/async_topic.py", line 30, in __call__
    self.func(*args, **self.kw)
  File "/usr/local/lib/python2.7/site-packages/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/tc_aws/vows/storage_vows.py", line 258, in topic
    storage.put(IMAGE_URL % '7', IMAGE_BYTES)
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 483, in wrapper
    future.result()
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 471, in wrapper
    result = f(*args, **kwargs)
  File "/tc_aws/tc_aws/storages/s3_storage.py", line 41, in put
    self.set(bytes, self._normalize_path(path), callback=once_written)
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 483, in wrapper
    future.result()
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 471, in wrapper
    result = f(*args, **kwargs)
  File "/tc_aws/tc_aws/aws/storage.py", line 80, in set
    callback=callback,
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 483, in wrapper
    future.result()
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 471, in wrapper
    result = f(*args, **kwargs)
  File "/tc_aws/tc_aws/aws/bucket.py", line 111, in put
    session.call(**args)
  File "/usr/local/lib/python2.7/site-packages/tornado_botocore/base.py", line 154, in call
    callback=callback
  File "/usr/local/lib/python2.7/site-packages/tornado_botocore/base.py", line 110, in _make_api_call
    callback=callback
  File "/usr/local/lib/python2.7/site-packages/tornado_botocore/base.py", line 101, in _make_request
    callback=callback
  File "/usr/local/lib/python2.7/site-packages/tornado_botocore/base.py", line 74, in _send_request
    proxy_port=self.proxy_port
  File "/usr/local/lib/python2.7/site-packages/tornado/httpclient.py", line 443, in __init__
    self.body = body
  File "/usr/local/lib/python2.7/site-packages/tornado/httpclient.py", line 488, in body
    self._body = utf8(value)
  File "/usr/local/lib/python2.7/site-packages/tornado/escape.py", line 198, in utf8
    "Expected bytes, unicode, or None; got %r" % type(value)
TypeError: Expected bytes, unicode, or None; got <type 'instance'>
```

When setting the body to request.body.buf however, it was getting through.