### PR TITLE
Don't rely on the `pip` library in setup.py, it may break

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,10 @@ For more information on creating source distributions, see
 http://docs.python.org/2/distutils/sourcedist.html
 
 """
+import fileinput
 import os
 import tornado_botocore as app
-import uuid
 
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -42,7 +41,7 @@ def read(fname):
         return ''
 
 
-REQUIREMENTS = [str(r.req) for r in parse_requirements('requirements.txt', session=uuid.uuid1())]
+REQUIREMENTS = [line for line in fileinput.input(files=['requirements.txt'])]
 
 
 setup(


### PR DESCRIPTION
The `pip` library never intended for their APIs to be used publicly, as detailed
in https://github.com/pypa/pip/issues/2286.

With pip 10 now available the `pip.req` module is no longer available and that
breaks installation of tornado-botocore on installations with pip 10 or newer.

Since the functionality of the library mostly was to read in dependencies
specified in `requirements.txt`, it's quite easy to fix this by just reading
the content of `requirements.txt` line by line and putting that into an array.