### PR TITLE
On error response body might be None, which causes exception in botocore

### DIFF
--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -126,7 +126,7 @@ class Botocore(object):
             'status_code': http_response.code,
         }
         if response_dict['status_code'] >= 300:
-            response_dict['body'] = http_response.body
+            response_dict['body'] = http_response.body or ''
         elif operation_model.has_streaming_output:
             response_dict['body'] = botocore.response.StreamingBody(
                 http_response.buffer,


### PR DESCRIPTION
tornado's http response on error might have body not set and it will default to None. Botocore expects body to always be string/bytes and will throw exception trying to parse generic error using .strip() on body. https://github.com/boto/botocore/blob/develop/botocore/parsers.py#L270